### PR TITLE
refactor: make prefetchQuery keys typesafe

### DIFF
--- a/site/lib/client-helpers.ts
+++ b/site/lib/client-helpers.ts
@@ -2,12 +2,8 @@ import * as g from "@/lib/__generated__/graphql"
 import { QueryClient } from "react-query"
 import { dehydrate } from "react-query/hydration"
 
-type FilterDocuments<T> = {
-  [P in keyof T]: P extends `${infer _U}Document` ? P : never
-}[keyof T]
-
 export async function prefetchQuery(
-  key: FilterDocuments<typeof g>,
+  key: Extract<keyof typeof g, `${string}Document`>,
   variables: Record<string, unknown>
 ) {
   const document = g[key]

--- a/site/lib/client-helpers.ts
+++ b/site/lib/client-helpers.ts
@@ -2,8 +2,15 @@ import * as g from "@/lib/__generated__/graphql"
 import { QueryClient } from "react-query"
 import { dehydrate } from "react-query/hydration"
 
-export async function prefetchQuery(key: string, variables: any) {
-  const document = g[(key + "Document") as keyof typeof g] as string
+type FilterDocuments<T> = {
+  [P in keyof T]: P extends `${infer _U}Document` ? P : never
+}[keyof T]
+
+export async function prefetchQuery(
+  key: FilterDocuments<typeof g>,
+  variables: Record<string, unknown>
+) {
+  const document = g[key]
   const client = new QueryClient()
 
   await client.prefetchQuery(

--- a/site/pages/image/[slug].tsx
+++ b/site/pages/image/[slug].tsx
@@ -180,7 +180,7 @@ export const getServerSideProps = wrapRequest(async (ctx) => {
       },
     })
     .catch(console.error)
-  const dehydratedState = await prefetchQuery("OneImage", { slug })
+  const dehydratedState = await prefetchQuery("OneImageDocument", { slug })
   return {
     props: {
       slug,

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -102,7 +102,7 @@ export default function Home() {
 }
 
 export const getServerSideProps = wrapRequest(async (ctx) => {
-  const dehydratedState = await prefetchQuery("Homepage", {
+  const dehydratedState = await prefetchQuery("HomepageDocument", {
     take: 100,
     skip: 0,
   })

--- a/site/pages/person/[personId].tsx
+++ b/site/pages/person/[personId].tsx
@@ -25,7 +25,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
   }
   const id = Number(personId)
 
-  const dehydratedState = await prefetchQuery("PersonPage", { id })
+  const dehydratedState = await prefetchQuery("PersonPageDocument", { id })
   return {
     props: { dehydratedState },
   }

--- a/site/pages/profile/index.tsx
+++ b/site/pages/profile/index.tsx
@@ -28,7 +28,7 @@ function Image() {
 }
 
 export const getServerSideProps: GetServerSideProps = async (ctx) => {
-  const dehydratedState = await prefetchQuery("Me", {})
+  const dehydratedState = await prefetchQuery("MeDocument", {})
   return {
     props: { dehydratedState },
   }


### PR DESCRIPTION
Could alternatively be changed to:
```typescript
type FilterDocuments<T> = {
  [P in keyof T]: P extends `${infer U}Document` ? U : never
}[keyof T]

FilterDocuments<typeof g>
```
If shorter function parameters are preferred